### PR TITLE
Fix elevator power threshold.

### DIFF
--- a/game/room/hall1f.tscn
+++ b/game/room/hall1f.tscn
@@ -36,7 +36,7 @@ locked = false
 
 transform/pos = Vector2( 0, -183 )
 power_cell_id = "Elevator"
-threshold = 0.7
+threshold = 0.6
 target_room_name = "hall2f"
 spawn_tag = "Elevator"
 


### PR DESCRIPTION
1F and 2F thresholds were not matching.

This is a harmless oversight, I'm considering leaving out of the LD fixes.